### PR TITLE
docs: use American English spelling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -28,7 +28,7 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: Expected behaviour
+      label: Expected behavior
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ will be `v1.0.0`.
 - gitleaks wrapper (`src/scanners/secrets.ts`) and `.gitleaks.toml` with a
   custom `LLM_WIKI_*` token rule.
 - `sync` command: end-to-end pipeline with `--json`, `--explain-dups`,
-  hash-redacted scan log, and quarantine-on-DENY behaviour.
+  hash-redacted scan log, and quarantine-on-DENY behavior.
 - `lint` command: per-folder zod frontmatter schemas, wikilink resolution
   with orphan detection, and Dataview block sanity check.
 - `init` command: scaffolds an Obsidian-ready vault that lints clean.


### PR DESCRIPTION
## Summary

- Replace "behaviour" with "behavior" in `CHANGELOG.md` and the bug-report
  template (`.github/ISSUE_TEMPLATE/bug.yml`).

## Why

Per project preference (American English in all written content).

## Test plan

- [x] No code changes; CI should pass.