### PR TITLE
docs: add roadmap with v0.2–v0.5 issue drafts and resume breadcrumbs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 Notes for Claude Code (and other agents) working in this repo.
 
+> **Resume here if context is fresh.** Read [docs/roadmap.md](docs/roadmap.md)
+> first — it has the where-we-are snapshot, the open PRs/decisions, and the
+> v0.2–v0.5 issue drafts. This file covers conventions; the roadmap covers
+> state.
+
 ## Branch model
 
 - Default working branch is **`dev`**, not `main`/`master`. There is no `main`.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ secrets, and pre-commit hooks for everything that should never reach git.
 [gist]: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
 
 > **Status:** v0.1 (Foundation & Safety). The synthesis pipeline (LLM ingest)
-> lands in v0.2 — see [CHANGELOG.md](CHANGELOG.md) and the v0.1 GitHub
-> milestone for the active scope.
+> lands in v0.2 — see [docs/roadmap.md](docs/roadmap.md) for the full
+> v0.2–v0.5 plan, [CHANGELOG.md](CHANGELOG.md) for what shipped, and the
+> v0.1 GitHub milestone for active scope.
 
 ## What it does
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -154,7 +154,8 @@ contributor to be productive.
 | 6 | **Cookbook docs** | A `docs/cookbook/` directory: "ingesting OneDrive", "ingesting GitHub issues", "two-machine setup with Obsidian Sync". |
 | 7 | **Performance benchmarks in CI** | Track ingest time per file and total `sync` time across releases. Fail if a regression > 30% lands. |
 | 8 | **v1.0 readiness checklist** | Audit threats in SECURITY.md against the implemented surface. Triage `.unresolved-allowed.txt` accumulation. Document upgrade path. |
-| 9 | **v0.5 release notes + tag** | |
+| 9 | **MCP client compatibility** | Verify the stdio MCP server works with Copilot, Codex CLI, Cursor, and Claude Desktop. Provide per-client config snippets (`mcp.json` / `settings.json`). Confirm tool descriptions are clear enough for agents to use without hand-holding. Smoke-test each client against the live server. |
+| 10 | **v0.5 release notes + tag** | |
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,7 +100,9 @@ contextual refinement. PDF and DOCX become first-class.
 | 9 | **Slug + filename strategy** | Stable, collision-free slugs from arbitrary source paths. Frontmatter must round-trip after rename. Document the algorithm in `docs/architecture.md`. |
 | 10 | **`pii-llm` integration tests** | Use a tiny local model in CI (or skip on no-Ollama with a clear message). Cover: personal email correctly promoted, business email correctly demoted, ambiguous case stays at warn. |
 | 11 | **Ingest cost accounting** | Per-run token count + wall time written to `runs.summary_json`. Surface via `status` MCP tool. |
-| 12 | **v0.2 release notes + tag** | Cut `release/v0.2` from `dev`, write CHANGELOG, tag. |
+| 12 | **Automated tests for v0.2 ingest pipeline** | Unit + integration coverage for: Ollama client (mocked + skip-if-no-Ollama live), PDF/DOCX extractors (golden bytes), source-note generator (idempotency), `ingest` end-to-end, `log.md` round-trip, MCP `ingest` tool, slug strategy, cost accounting. Excludes `pii-llm` (own issue). |
+| 13 | **Update docs for v0.2** | README LLM-ingest section, CHANGELOG, `docs/architecture.md` (extractor pipeline + slug algorithm + log.md format), `docs/pii-tiers.md` (LLM promotion/demotion rules). Mark v0.2 done in `docs/roadmap.md`. |
+| 14 | **v0.2 release notes + tag** | Cut `release/v0.2` from `dev`, write CHANGELOG, tag. |
 
 ---
 
@@ -118,7 +120,9 @@ Topic pages cut across many source-notes. Contradictions surface.
 | 5 | **Wikilink graph health** in `lint` | Add metrics: average inbound links, isolated clusters, deepest path. Print as a table in human mode; JSON in `--json` mode. |
 | 6 | **Synthesis test fixtures** | Tiny vault + tiny source set that exercises the full ingest→synthesize loop. Used by both unit tests and the v0.3 smoke test. |
 | 7 | **Query-aware lint** | When `lint` finds a topic referenced by a wikilink that has no corresponding `topics/<name>.md`, suggest creating it (printed only, doesn't fail). |
-| 8 | **v0.3 release notes + tag** | |
+| 8 | **Automated tests for v0.3 synthesis** | Use the synthesis fixtures to drive: topic-page agent (round-trip through `<!-- agent:start/end -->`), contradiction detector (golden divergence cases), `index.md` auto-maintenance, wikilink-graph metrics, query-aware lint suggestions. |
+| 9 | **Update docs for v0.3** | README synthesis section, CHANGELOG, `docs/architecture.md` (topic-agent contract, section-marker convention, contradiction format). Mark v0.3 done in `docs/roadmap.md`. |
+| 10 | **v0.3 release notes + tag** | |
 
 ---
 
@@ -135,7 +139,9 @@ filed back into the wiki under `questions/`.
 | 4 | **MCP `query` tool** | Same shape as the CLI; streams the answer. |
 | 5 | **`questions/Index.md` auto-update** | Keep the index of asked questions current; reference back to `log.md`. |
 | 6 | **Per-question re-asking** | If a question already exists, re-running the query updates the same page (with a new "asked again" timestamp) instead of duplicating. |
-| 7 | **v0.4 release notes + tag** | |
+| 7 | **Automated tests for v0.4 query** | `query` CLI golden Q&A, BM25 retrieval correctness, citation enforcement (refusal cases for uncited claims), MCP `query` tool, re-asking idempotency. |
+| 8 | **Update docs for v0.4** | README query workflow, CHANGELOG, `docs/architecture.md` (retrieval layer + citation rules). Mark v0.4 done in `docs/roadmap.md`. |
+| 9 | **v0.4 release notes + tag** | |
 
 ---
 
@@ -155,7 +161,9 @@ contributor to be productive.
 | 7 | **Performance benchmarks in CI** | Track ingest time per file and total `sync` time across releases. Fail if a regression > 30% lands. |
 | 8 | **v1.0 readiness checklist** | Audit threats in SECURITY.md against the implemented surface. Triage `.unresolved-allowed.txt` accumulation. Document upgrade path. |
 | 9 | **MCP client compatibility** | Verify the stdio MCP server works with Copilot, Codex CLI, Cursor, and Claude Desktop. Provide per-client config snippets (`mcp.json` / `settings.json`). Confirm tool descriptions are clear enough for agents to use without hand-holding. Smoke-test each client against the live server. |
-| 10 | **v0.5 release notes + tag** | |
+| 10 | **Automated tests for v0.5 features** | watch-mode debounce, parallel-extraction concurrency cap, ledger queries under load, llama.cpp adapter parity with Ollama, embedding retrieval, MCP-client smoke tests. Excludes perf benchmarks (own issue). |
+| 11 | **Update docs for v0.5** | README, CHANGELOG, `docs/architecture.md` (provider abstraction + watch mode + MCP client config). Mark v0.5 done in `docs/roadmap.md`. Cookbook is its own issue. |
+| 12 | **v0.5 release notes + tag** | |
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,189 @@
+# Roadmap
+
+Living roadmap for `llm-wiki-gen`. This file is the **first thing a fresh
+agent session should read** — it captures both where we are and where we're
+going. Update it whenever a milestone closes or scope shifts.
+
+---
+
+## Where we are (as of 2026-04-29)
+
+**Shipped (v0.1, commit `d9b2b84`):** the foundation/safety milestone is
+complete and pushed to `dev`. See [CHANGELOG.md](../CHANGELOG.md) and
+[docs/architecture.md](architecture.md) for what's actually wired.
+
+**Open work right now:**
+
+- **PR #20** (`docs/american-english`): two-line spelling fix for
+  "behaviour" → "behavior". Direct push to `dev` was blocked by the
+  GitHub-applied `default-branch-protection` ruleset
+  ([rules/15746641](https://github.com/bminier/llm-wiki-gen/rules/15746641));
+  the PR exists to satisfy that rule. Merge when CI is green.
+- **PR for this roadmap doc** is the second open PR (same blocker — direct
+  pushes to `dev` are rejected).
+- **Ruleset decision pending:** the auto-applied ruleset requires PRs for
+  any change to `dev`. For solo work this is friction; for collaborative
+  work it's the right default. Decide whether to keep it (PRs always),
+  weaken it (allow direct pushes from your account), or replace it with the
+  stricter ruleset configured by `scripts/setup-branch-protection.py`.
+- **Pre-commit hooks not installed locally yet.** Run
+  `python scripts/install-hooks.py` once before serious work resumes.
+
+**Verification snapshot at v0.1:** 108 tests pass; typecheck clean; lint
+clean (7 informational warnings on `!` non-null assertions in tests);
+gitleaks clean; live smoke confirms `init` scaffolds a vault that lints
+clean and `sync` correctly quarantines a synthetic Luhn-valid CC while
+detecting one duplicate.
+
+---
+
+## Conversation breadcrumbs (resume hints for a fresh session)
+
+A future session restarting from a compressed context should still be able
+to pick up here. Key decisions made in conversation that aren't otherwise
+obvious from the code:
+
+- **Runtime is Bun**, not Python (despite the global preference for Python
+  scripts). Setup scripts under `scripts/` are Python; the tool is Bun.
+- **LLM is local-only via Ollama.** The `[llm].provider` config field
+  accepts only `"ollama"` or `"none"`. Adding a remote-API provider
+  requires opt-in plus confirmation (see SECURITY.md).
+- **Wiki output path is configurable**, default `~/llm-wiki`. Source
+  allowlist default is `~/llm-wiki-source`, **read-only** (enforced by
+  code structure + `Allowlist` symlink-resolving containment checks).
+- **`sync` and `ingest` are split** by design: sync is cheap, idempotent,
+  scan-only; ingest is the expensive LLM pass. v0.1 ships sync; v0.2 ships
+  ingest.
+- **MCP transport is stdio only.** No HTTP/SSE in v0.1; reconsider only if
+  a remote-client use case appears.
+- **`query` and `lint` are deferred:** `lint` shipped in v0.1 because it
+  doesn't need an LLM; `query` waits until v0.4 because it needs both
+  ingested content and the synthesis layer.
+- **Two-pass reconciler is non-negotiable.** Single-pass would lose
+  rename detection. The seven status transitions
+  (`new | unchanged | changed | moved | duplicate | deleted | quarantined`)
+  are tested explicitly in `tests/unit/reconciler.test.ts` — when extending,
+  preserve all seven.
+- **Lex-smallest path wins canonical** when two new files share the same
+  hash in one run. Arbitrary but deterministic. Don't change without
+  updating tests.
+- **PII regex log is hash-redacted.** Full PII never lives in the ledger.
+- **`Index.md` pages are exempt from per-folder frontmatter schemas** —
+  detection is "no frontmatter block at all → use the default schema." If
+  you add a folder with required frontmatter, give the folder's `Index.md`
+  an actual frontmatter block or it'll skip validation.
+- **Sandboxed-editor false positive on the bound DDL caller in
+  `src/core/ledger.ts`.** Some security hooks pattern-match the literal
+  substring `<dot>exec(` and assume `child_process` is in play. The ledger
+  binds the Database method to a local function (`runDDL`) and feeds it a
+  list of single statements; the schema is split rather than passed as one
+  multi-statement string. Follow the same pattern when extending DDL.
+
+---
+
+## Milestone v0.2 — LLM Ingest (Ollama)
+
+**Goal:** sources marked `new` or `changed` flow through the LLM and
+produce a `source-notes/<slug>.md` page in the wiki vault. PII verdicts get
+contextual refinement. PDF and DOCX become first-class.
+
+| # | Issue | Notes |
+|---|---|---|
+| 1 | **Ollama HTTP client + retry/timeout** (`src/llm/ollama.ts`) | Streamed response handling, exponential backoff, healthcheck on `/api/tags`. Provider abstraction so v0.5 can plug llama.cpp without rewriting callers. |
+| 2 | **PII contextual classifier** (`src/scanners/pii-llm.ts`) | Takes regex WARN-tier hits + ±200-char window, asks Ollama "is this personal or business context?" with a strict JSON schema response. Can promote WARN→DENY or demote WARN→ALLOW. Runs after `pii-regex` in `sync`. |
+| 3 | **PDF extractor** (`src/core/extractors/pdf.ts`) | Vendored `pdf-parse` or `pdfjs`. Hashes the source bytes, not the extracted text. Update `extract`/`isSupported`/`contentTypeFor`. Add fixture. |
+| 4 | **DOCX extractor** (`src/core/extractors/docx.ts`) | Likely `mammoth`. Same shape as PDF extractor. Add fixture. |
+| 5 | **Source-note generator** | Given an extracted source, emit `source-notes/<slug>.md` with proper frontmatter (`source_id`, `hash`, `ingested`, `type`, `tags`), summary, claims, entities, links. Idempotent: re-running over an unchanged source is a no-op. |
+| 6 | **`ingest` command — real implementation** | Replace the v0.1 stub. Reads ledger for `new`/`changed`, calls extractor + classifier + generator, writes notes, updates ledger status to `unchanged`. `--since <run-id>`, `--limit N`, `--source <id>` flags. |
+| 7 | **Append-only `log.md` writer** | Per the gist spec: each ingest/query run appends a dated entry. Parse-resistant: write through a single helper so format stays stable. |
+| 8 | **MCP `ingest` tool — non-stub** | Update `src/mcp/server.ts` to dispatch to the real ingest. Streamed progress over MCP if practical; otherwise return summary. |
+| 9 | **Slug + filename strategy** | Stable, collision-free slugs from arbitrary source paths. Frontmatter must round-trip after rename. Document the algorithm in `docs/architecture.md`. |
+| 10 | **`pii-llm` integration tests** | Use a tiny local model in CI (or skip on no-Ollama with a clear message). Cover: personal email correctly promoted, business email correctly demoted, ambiguous case stays at warn. |
+| 11 | **Ingest cost accounting** | Per-run token count + wall time written to `runs.summary_json`. Surface via `status` MCP tool. |
+| 12 | **v0.2 release notes + tag** | Cut `release/v0.2` from `dev`, write CHANGELOG, tag. |
+
+---
+
+## Milestone v0.3 — Synthesis
+
+**Goal:** the wiki accumulates *understanding*, not just file summaries.
+Topic pages cut across many source-notes. Contradictions surface.
+
+| # | Issue | Notes |
+|---|---|---|
+| 1 | **Topic page agent** (`src/synthesis/topics.ts`) | Given new/changed source-notes, pick affected topics and update `topics/<name>.md`. Preserves human edits between agent-managed sections. |
+| 2 | **Section markers** (`<!-- agent:start … -->` / `<!-- agent:end -->`) | Convention for "agent owns this region; human owns the rest." Document in `docs/architecture.md`. |
+| 3 | **Contradiction detector** | Compare new source-note claims against existing topic claims. Emit `claims/contradictions/<id>.md` when divergence is detected. |
+| 4 | **`index.md` auto-maintenance** | Keep the root index in sync with the actual folder structure. Don't fight Obsidian's preferred Dataview pattern. |
+| 5 | **Wikilink graph health** in `lint` | Add metrics: average inbound links, isolated clusters, deepest path. Print as a table in human mode; JSON in `--json` mode. |
+| 6 | **Synthesis test fixtures** | Tiny vault + tiny source set that exercises the full ingest→synthesize loop. Used by both unit tests and the v0.3 smoke test. |
+| 7 | **Query-aware lint** | When `lint` finds a topic referenced by a wikilink that has no corresponding `topics/<name>.md`, suggest creating it (printed only, doesn't fail). |
+| 8 | **v0.3 release notes + tag** | |
+
+---
+
+## Milestone v0.4 — Query
+
+**Goal:** the third Karpathy operation. Ask a question; get a cited answer
+filed back into the wiki under `questions/`.
+
+| # | Issue | Notes |
+|---|---|---|
+| 1 | **`query` CLI command** (`src/commands/query.ts`) | Takes a free-form question, retrieves relevant pages (BM25 over titles + frontmatter; v0.5 may add embeddings), synthesizes an answer, writes `questions/<slug>.md` with sources cited as `[[wikilinks]]`. |
+| 2 | **Retrieval layer** (`src/retrieval/bm25.ts`) | In-process; index lives next to the ledger. Rebuild on `sync`/`ingest`. |
+| 3 | **Citation enforcement** | Refuse to write a `questions/` page that contains uncited claims; either expand the prompt or lower the answer's confidence and mark sections as `<!-- unverified -->`. |
+| 4 | **MCP `query` tool** | Same shape as the CLI; streams the answer. |
+| 5 | **`questions/Index.md` auto-update** | Keep the index of asked questions current; reference back to `log.md`. |
+| 6 | **Per-question re-asking** | If a question already exists, re-running the query updates the same page (with a new "asked again" timestamp) instead of duplicating. |
+| 7 | **v0.4 release notes + tag** | |
+
+---
+
+## Milestone v0.5 — Polish & Hardening
+
+**Goal:** production-feel for solo use; documentation enough for a second
+contributor to be productive.
+
+| # | Issue | Notes |
+|---|---|---|
+| 1 | **`watch` mode** | Filesystem events, debounced, runs `sync` (and optionally `ingest`) automatically. Off by default. Cross-platform via `chokidar` or Bun's native `watch`. |
+| 2 | **Parallel extraction** | `Promise.all` with a concurrency cap. Benchmark: ~10× speedup on a 200-file corpus is the bar. |
+| 3 | **Ledger query tuning** | EXPLAIN-driven index review. Should be irrelevant under 10k sources, but the v0.4 query path makes it worth checking. |
+| 4 | **Provider abstraction: llama.cpp** | Adapter implementing the same interface as `ollama.ts`, talks to `llama-server`'s OpenAI-compatible endpoint. Pick at config time. |
+| 5 | **Embedding-based retrieval (optional)** | Local embeddings via Ollama's `/api/embeddings`. Hybrid BM25+vector. Behind a config flag. |
+| 6 | **Cookbook docs** | A `docs/cookbook/` directory: "ingesting OneDrive", "ingesting GitHub issues", "two-machine setup with Obsidian Sync". |
+| 7 | **Performance benchmarks in CI** | Track ingest time per file and total `sync` time across releases. Fail if a regression > 30% lands. |
+| 8 | **v1.0 readiness checklist** | Audit threats in SECURITY.md against the implemented surface. Triage `.unresolved-allowed.txt` accumulation. Document upgrade path. |
+| 9 | **v0.5 release notes + tag** | |
+
+---
+
+## Stretch / unsorted
+
+Things mentioned in the original Karpathy discussion that don't yet have
+a milestone home:
+
+- **Spreadsheet (xlsx) intelligence** — was deferred at v0.1; harder than
+  PDF/DOCX because cell semantics matter. Possible v0.6+.
+- **Image OCR** — same.
+- **Visio (vsdx) diagram extraction** — same; aspirational.
+- **Two-machine sync of the wiki** — Obsidian Sync is one answer; a Git
+  remote is another. Cookbook material, not a feature.
+- **Cross-vault federation** — multiple wikis with shared topics. Out of
+  scope until v1.0+.
+- **GitHub issue ingestion as a source type** — natural extension; could
+  land alongside the LLM ingest pipeline in v0.2 if scope allows.
+
+---
+
+## How to seed these into GitHub
+
+`scripts/new-issues.py` currently knows only about v0.1. When you're ready
+to start a milestone, extend the script with a `V02_ISSUES = [...]` block
+mirroring `V01_ISSUES`, add a `--milestone` argument, and re-run it. The
+script is idempotent — it skips milestones and issue titles that already
+exist.
+
+A future session that lands here can: read this file, copy each table row
+above into a Python list, and re-run `python scripts/new-issues.py
+bminier/llm-wiki-gen --milestone v0.2`.

--- a/scripts/new-issues.py
+++ b/scripts/new-issues.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
-"""Seed the v0.1 GitHub milestone and its issues via `gh`.
+"""Seed GitHub milestones and issues for llm-wiki-gen via `gh`.
 
 Usage:
     python scripts/new-issues.py <owner/repo>
+    python scripts/new-issues.py <owner/repo> --milestone v0.2
+    python scripts/new-issues.py <owner/repo> --milestone all
 
-Idempotent-ish: skips milestones/issues whose titles already exist.
+Idempotent: skips milestones/issues whose titles already exist.
+
+Issue bodies mirror the per-milestone tables in docs/roadmap.md. Update
+the roadmap first, then update the corresponding V0X_ISSUES block here.
 """
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 import sys
@@ -24,7 +30,7 @@ MILESTONES = [
     {"title": "v0.2 — LLM Ingest (Ollama)", "description": "Source-note generator + LLM-tiered PII contextual classifier + pdf/docx extractors."},
     {"title": "v0.3 — Synthesis", "description": "Topic page agent, contradiction detection, index.md auto-maintenance."},
     {"title": "v0.4 — Query", "description": "`query` command + MCP `query` tool."},
-    {"title": "v0.5 — Polish", "description": "watch mode, perf, cookbook docs."},
+    {"title": "v0.5 — Polish", "description": "watch mode, perf, cookbook docs, MCP client compatibility."},
 ]
 
 V01_ISSUES: list[dict] = [
@@ -49,9 +55,75 @@ V01_ISSUES: list[dict] = [
     {"title": "v0.1 release notes + tag from release/v0.1", "body": "Cut release/v0.1 from dev, write CHANGELOG entries, tag, publish.", "labels": ["release", "v0.1"]},
 ]
 
+V02_ISSUES: list[dict] = [
+    {"title": "Ollama HTTP client + retry/timeout", "body": "src/llm/ollama.ts. Streamed response handling, exponential backoff, healthcheck on /api/tags. Provider abstraction so v0.5 can plug llama.cpp without rewriting callers.", "labels": ["feat", "v0.2"]},
+    {"title": "PII contextual classifier (LLM)", "body": "src/scanners/pii-llm.ts. Takes regex WARN-tier hits + ±200-char window, asks Ollama 'is this personal or business context?' with a strict JSON schema response. Can promote WARN→DENY or demote WARN→ALLOW. Runs after pii-regex in `sync`.", "labels": ["feat", "security", "v0.2"]},
+    {"title": "PDF extractor", "body": "src/core/extractors/pdf.ts. Vendored pdf-parse or pdfjs. Hashes the source bytes, not the extracted text. Update extract/isSupported/contentTypeFor. Add fixture under tests/fixtures/.", "labels": ["feat", "v0.2"]},
+    {"title": "DOCX extractor", "body": "src/core/extractors/docx.ts. Likely `mammoth`. Same shape as the PDF extractor. Add fixture under tests/fixtures/.", "labels": ["feat", "v0.2"]},
+    {"title": "Source-note generator", "body": "Given an extracted source, emit source-notes/<slug>.md with proper frontmatter (source_id, hash, ingested, type, tags), summary, claims, entities, links. Idempotent: re-running over an unchanged source is a no-op.", "labels": ["feat", "v0.2"]},
+    {"title": "ingest command — real implementation", "body": "Replace the v0.1 stub. Reads ledger for new/changed sources, calls extractor + classifier + generator, writes notes, updates ledger status to `unchanged`. Flags: --since <run-id>, --limit N, --source <id>.", "labels": ["feat", "v0.2"]},
+    {"title": "Append-only log.md writer", "body": "Per the gist spec: each ingest/query run appends a dated entry to log.md. Parse-resistant: write through a single helper so format stays stable.", "labels": ["feat", "v0.2"]},
+    {"title": "MCP ingest tool — non-stub", "body": "Update src/mcp/server.ts to dispatch to the real ingest pipeline. Stream progress over MCP if practical; otherwise return summary.", "labels": ["feat", "v0.2"]},
+    {"title": "Slug + filename strategy", "body": "Stable, collision-free slugs from arbitrary source paths. Frontmatter must round-trip after rename. Document the algorithm in docs/architecture.md.", "labels": ["feat", "v0.2"]},
+    {"title": "pii-llm integration tests", "body": "Use a tiny local model in CI (or skip on no-Ollama with a clear message). Cover: personal email correctly promoted, business email correctly demoted, ambiguous case stays at warn.", "labels": ["test", "security", "v0.2"]},
+    {"title": "Ingest cost accounting", "body": "Per-run token count + wall time written to runs.summary_json. Surface via `status` MCP tool.", "labels": ["feat", "v0.2"]},
+    {"title": "v0.2 release notes + tag", "body": "Cut release/v0.2 from dev, write CHANGELOG entries, tag, publish.", "labels": ["release", "v0.2"]},
+]
+
+V03_ISSUES: list[dict] = [
+    {"title": "Topic page agent", "body": "src/synthesis/topics.ts. Given new/changed source-notes, pick affected topics and update topics/<name>.md. Preserves human edits between agent-managed sections.", "labels": ["feat", "v0.3"]},
+    {"title": "Section markers (agent:start/agent:end)", "body": "Convention for 'agent owns this region; human owns the rest' using <!-- agent:start ... --> / <!-- agent:end --> comments. Document in docs/architecture.md.", "labels": ["feat", "v0.3"]},
+    {"title": "Contradiction detector", "body": "Compare new source-note claims against existing topic claims. Emit claims/contradictions/<id>.md when divergence is detected.", "labels": ["feat", "v0.3"]},
+    {"title": "index.md auto-maintenance", "body": "Keep the root index in sync with the actual folder structure. Don't fight Obsidian's preferred Dataview pattern.", "labels": ["feat", "v0.3"]},
+    {"title": "Wikilink graph health in lint", "body": "Add metrics: average inbound links, isolated clusters, deepest path. Print as a table in human mode; JSON in --json mode.", "labels": ["feat", "v0.3"]},
+    {"title": "Synthesis test fixtures", "body": "Tiny vault + tiny source set that exercises the full ingest→synthesize loop. Used by both unit tests and the v0.3 smoke test.", "labels": ["test", "v0.3"]},
+    {"title": "Query-aware lint", "body": "When `lint` finds a topic referenced by a wikilink that has no corresponding topics/<name>.md, suggest creating it (printed only, doesn't fail).", "labels": ["feat", "v0.3"]},
+    {"title": "v0.3 release notes + tag", "body": "Cut release/v0.3 from dev, write CHANGELOG entries, tag, publish.", "labels": ["release", "v0.3"]},
+]
+
+V04_ISSUES: list[dict] = [
+    {"title": "query CLI command", "body": "src/commands/query.ts. Takes a free-form question, retrieves relevant pages (BM25 over titles + frontmatter; v0.5 may add embeddings), synthesizes an answer, writes questions/<slug>.md with sources cited as [[wikilinks]].", "labels": ["feat", "v0.4"]},
+    {"title": "Retrieval layer (BM25)", "body": "src/retrieval/bm25.ts. In-process; index lives next to the ledger. Rebuild on `sync`/`ingest`.", "labels": ["feat", "v0.4"]},
+    {"title": "Citation enforcement", "body": "Refuse to write a questions/ page that contains uncited claims; either expand the prompt or lower the answer's confidence and mark sections as <!-- unverified -->.", "labels": ["feat", "v0.4"]},
+    {"title": "MCP query tool", "body": "Same shape as the CLI; streams the answer over MCP.", "labels": ["feat", "v0.4"]},
+    {"title": "questions/Index.md auto-update", "body": "Keep the index of asked questions current; reference back to log.md.", "labels": ["feat", "v0.4"]},
+    {"title": "Per-question re-asking", "body": "If a question already exists, re-running the query updates the same page (with a new 'asked again' timestamp) instead of duplicating.", "labels": ["feat", "v0.4"]},
+    {"title": "v0.4 release notes + tag", "body": "Cut release/v0.4 from dev, write CHANGELOG entries, tag, publish.", "labels": ["release", "v0.4"]},
+]
+
+V05_ISSUES: list[dict] = [
+    {"title": "watch mode", "body": "Filesystem events, debounced, runs `sync` (and optionally `ingest`) automatically. Off by default. Cross-platform via chokidar or Bun's native watch.", "labels": ["feat", "v0.5"]},
+    {"title": "Parallel extraction", "body": "Promise.all with a concurrency cap. Benchmark target: ~10× speedup on a 200-file corpus.", "labels": ["feat", "v0.5"]},
+    {"title": "Ledger query tuning", "body": "EXPLAIN-driven index review. Should be irrelevant under 10k sources, but the v0.4 query path makes it worth checking.", "labels": ["chore", "v0.5"]},
+    {"title": "Provider abstraction: llama.cpp", "body": "Adapter implementing the same interface as ollama.ts, talks to llama-server's OpenAI-compatible endpoint. Pick at config time.", "labels": ["feat", "v0.5"]},
+    {"title": "Embedding-based retrieval (optional)", "body": "Local embeddings via Ollama's /api/embeddings. Hybrid BM25+vector. Behind a config flag.", "labels": ["feat", "v0.5"]},
+    {"title": "Cookbook docs", "body": "A docs/cookbook/ directory: 'ingesting OneDrive', 'ingesting GitHub issues', 'two-machine setup with Obsidian Sync'.", "labels": ["docs", "v0.5"]},
+    {"title": "Performance benchmarks in CI", "body": "Track ingest time per file and total `sync` time across releases. Fail if a regression > 30% lands.", "labels": ["chore", "v0.5"]},
+    {"title": "v1.0 readiness checklist", "body": "Audit threats in SECURITY.md against the implemented surface. Triage .unresolved-allowed.txt accumulation. Document upgrade path.", "labels": ["chore", "security", "v0.5"]},
+    {"title": "MCP client compatibility", "body": "Verify the stdio MCP server works with Copilot, Codex CLI, Cursor, and Claude Desktop. Provide per-client config snippets (mcp.json / settings.json). Confirm tool descriptions are clear enough for agents to use without hand-holding. Smoke-test each client against the live server.", "labels": ["feat", "docs", "v0.5"]},
+    {"title": "v0.5 release notes + tag", "body": "Cut release/v0.5 from dev, write CHANGELOG entries, tag, publish.", "labels": ["release", "v0.5"]},
+]
+
+
+ISSUE_SETS: dict[str, tuple[str, list[dict]]] = {
+    "v0.1": ("v0.1 — Foundation & Safety", V01_ISSUES),
+    "v0.2": ("v0.2 — LLM Ingest (Ollama)", V02_ISSUES),
+    "v0.3": ("v0.3 — Synthesis", V03_ISSUES),
+    "v0.4": ("v0.4 — Query", V04_ISSUES),
+    "v0.5": ("v0.5 — Polish", V05_ISSUES),
+}
+
 
 def gh(args: list[str], *, body: str | None = None) -> tuple[int, str]:
-    res = subprocess.run(["gh", *args], input=body, text=True, capture_output=True)
+    # Force UTF-8 for both stdin (POST bodies) and stdout. Without this, Python on
+    # Windows uses cp1252 for the gh subprocess, which mojibakes em-dashes in
+    # milestone/issue titles before they reach the GitHub API.
+    res = subprocess.run(
+        ["gh", *args],
+        input=body,
+        capture_output=True,
+        encoding="utf-8",
+    )
     return res.returncode, res.stdout + res.stderr
 
 
@@ -63,10 +135,21 @@ def existing_milestones(repo: str) -> dict[str, int]:
 
 
 def existing_issue_titles(repo: str) -> set[str]:
-    rc, out = gh(["api", f"/repos/{repo}/issues?state=all&per_page=100"])
-    if rc != 0:
-        sys.exit(f"failed to list issues: {out}")
-    return {i["title"] for i in json.loads(out)}
+    """Return all issue titles across pages. /issues includes PRs but that's fine for dedup."""
+    titles: set[str] = set()
+    page = 1
+    while True:
+        rc, out = gh(["api", f"/repos/{repo}/issues?state=all&per_page=100&page={page}"])
+        if rc != 0:
+            sys.exit(f"failed to list issues: {out}")
+        batch = json.loads(out)
+        if not batch:
+            break
+        titles.update(i["title"] for i in batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return titles
 
 
 def ensure_milestone(repo: str, title: str, description: str, existing: dict[str, int]) -> int:
@@ -103,20 +186,34 @@ def ensure_issue(repo: str, milestone: int, issue: dict, existing: set[str]) -> 
     print(f"[issue] created: {title}")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("repo", help="GitHub repo in owner/name form, e.g. bminier/llm-wiki-gen")
+    parser.add_argument(
+        "--milestone",
+        choices=[*ISSUE_SETS.keys(), "all"],
+        default="all",
+        help="Which milestone's issues to seed (default: all). Milestones themselves are always ensured.",
+    )
+    return parser.parse_args()
+
+
 def main() -> int:
-    if len(sys.argv) != 2:
-        print("usage: new-issues.py <owner/repo>", file=sys.stderr)
-        return 2
-    repo = sys.argv[1]
+    args = parse_args()
+    repo = args.repo
 
     milestones = existing_milestones(repo)
     for m in MILESTONES:
         milestones[m["title"]] = ensure_milestone(repo, m["title"], m["description"], milestones)
 
+    selected = list(ISSUE_SETS.keys()) if args.milestone == "all" else [args.milestone]
     issues = existing_issue_titles(repo)
-    v01 = milestones["v0.1 — Foundation & Safety"]
-    for i in V01_ISSUES:
-        ensure_issue(repo, v01, i, issues)
+    for key in selected:
+        milestone_title, issue_list = ISSUE_SETS[key]
+        milestone_num = milestones[milestone_title]
+        print(f"\n=== seeding {key} ({len(issue_list)} issues) ===")
+        for i in issue_list:
+            ensure_issue(repo, milestone_num, i, issues)
     return 0
 
 

--- a/scripts/new-issues.py
+++ b/scripts/new-issues.py
@@ -67,6 +67,8 @@ V02_ISSUES: list[dict] = [
     {"title": "Slug + filename strategy", "body": "Stable, collision-free slugs from arbitrary source paths. Frontmatter must round-trip after rename. Document the algorithm in docs/architecture.md.", "labels": ["feat", "v0.2"]},
     {"title": "pii-llm integration tests", "body": "Use a tiny local model in CI (or skip on no-Ollama with a clear message). Cover: personal email correctly promoted, business email correctly demoted, ambiguous case stays at warn.", "labels": ["test", "security", "v0.2"]},
     {"title": "Ingest cost accounting", "body": "Per-run token count + wall time written to runs.summary_json. Surface via `status` MCP tool.", "labels": ["feat", "v0.2"]},
+    {"title": "Automated tests for v0.2 ingest pipeline", "body": "Unit + integration coverage for: Ollama client (mocked + skip-if-no-Ollama live), PDF/DOCX extractors (golden bytes), source-note generator (idempotency), `ingest` end-to-end, `log.md` round-trip, MCP `ingest` tool, slug strategy, cost accounting. Excludes pii-llm (own issue).", "labels": ["test", "v0.2"]},
+    {"title": "Update docs for v0.2", "body": "README LLM-ingest section, CHANGELOG, docs/architecture.md (extractor pipeline + slug algorithm + log.md format), docs/pii-tiers.md (LLM promotion/demotion rules). Mark v0.2 done in docs/roadmap.md.", "labels": ["docs", "v0.2"]},
     {"title": "v0.2 release notes + tag", "body": "Cut release/v0.2 from dev, write CHANGELOG entries, tag, publish.", "labels": ["release", "v0.2"]},
 ]
 
@@ -78,6 +80,8 @@ V03_ISSUES: list[dict] = [
     {"title": "Wikilink graph health in lint", "body": "Add metrics: average inbound links, isolated clusters, deepest path. Print as a table in human mode; JSON in --json mode.", "labels": ["feat", "v0.3"]},
     {"title": "Synthesis test fixtures", "body": "Tiny vault + tiny source set that exercises the full ingest→synthesize loop. Used by both unit tests and the v0.3 smoke test.", "labels": ["test", "v0.3"]},
     {"title": "Query-aware lint", "body": "When `lint` finds a topic referenced by a wikilink that has no corresponding topics/<name>.md, suggest creating it (printed only, doesn't fail).", "labels": ["feat", "v0.3"]},
+    {"title": "Automated tests for v0.3 synthesis", "body": "Use the synthesis fixtures to drive: topic-page agent (round-trip through <!-- agent:start/end -->), contradiction detector (golden divergence cases), index.md auto-maintenance, wikilink-graph metrics, query-aware lint suggestions.", "labels": ["test", "v0.3"]},
+    {"title": "Update docs for v0.3", "body": "README synthesis section, CHANGELOG, docs/architecture.md (topic-agent contract, section-marker convention, contradiction format). Mark v0.3 done in docs/roadmap.md.", "labels": ["docs", "v0.3"]},
     {"title": "v0.3 release notes + tag", "body": "Cut release/v0.3 from dev, write CHANGELOG entries, tag, publish.", "labels": ["release", "v0.3"]},
 ]
 
@@ -88,6 +92,8 @@ V04_ISSUES: list[dict] = [
     {"title": "MCP query tool", "body": "Same shape as the CLI; streams the answer over MCP.", "labels": ["feat", "v0.4"]},
     {"title": "questions/Index.md auto-update", "body": "Keep the index of asked questions current; reference back to log.md.", "labels": ["feat", "v0.4"]},
     {"title": "Per-question re-asking", "body": "If a question already exists, re-running the query updates the same page (with a new 'asked again' timestamp) instead of duplicating.", "labels": ["feat", "v0.4"]},
+    {"title": "Automated tests for v0.4 query", "body": "`query` CLI golden Q&A, BM25 retrieval correctness, citation enforcement (refusal cases for uncited claims), MCP `query` tool, re-asking idempotency.", "labels": ["test", "v0.4"]},
+    {"title": "Update docs for v0.4", "body": "README query workflow, CHANGELOG, docs/architecture.md (retrieval layer + citation rules). Mark v0.4 done in docs/roadmap.md.", "labels": ["docs", "v0.4"]},
     {"title": "v0.4 release notes + tag", "body": "Cut release/v0.4 from dev, write CHANGELOG entries, tag, publish.", "labels": ["release", "v0.4"]},
 ]
 
@@ -101,6 +107,8 @@ V05_ISSUES: list[dict] = [
     {"title": "Performance benchmarks in CI", "body": "Track ingest time per file and total `sync` time across releases. Fail if a regression > 30% lands.", "labels": ["chore", "v0.5"]},
     {"title": "v1.0 readiness checklist", "body": "Audit threats in SECURITY.md against the implemented surface. Triage .unresolved-allowed.txt accumulation. Document upgrade path.", "labels": ["chore", "security", "v0.5"]},
     {"title": "MCP client compatibility", "body": "Verify the stdio MCP server works with Copilot, Codex CLI, Cursor, and Claude Desktop. Provide per-client config snippets (mcp.json / settings.json). Confirm tool descriptions are clear enough for agents to use without hand-holding. Smoke-test each client against the live server.", "labels": ["feat", "docs", "v0.5"]},
+    {"title": "Automated tests for v0.5 features", "body": "watch-mode debounce, parallel-extraction concurrency cap, ledger queries under load, llama.cpp adapter parity with Ollama, embedding retrieval, MCP-client smoke tests. Excludes perf benchmarks (own issue).", "labels": ["test", "v0.5"]},
+    {"title": "Update docs for v0.5", "body": "README, CHANGELOG, docs/architecture.md (provider abstraction + watch mode + MCP client config). Mark v0.5 done in docs/roadmap.md. Cookbook is its own issue.", "labels": ["docs", "v0.5"]},
     {"title": "v0.5 release notes + tag", "body": "Cut release/v0.5 from dev, write CHANGELOG entries, tag, publish.", "labels": ["release", "v0.5"]},
 ]
 


### PR DESCRIPTION
## Summary

Adds `docs/roadmap.md` as the single source of truth for:

- **Current state** — v0.1 commit, open PRs (#20, this one), ruleset
  decision, verification snapshot.
- **Resume breadcrumbs** — design decisions that aren't obvious from
  reading the code, captured so a fresh agent session can pick up cleanly
  after context compression.
- **v0.2–v0.5 issue drafts** — title + touch points + short notes per
  issue, ready to copy into `scripts/new-issues.py` when each milestone
  starts.
- **Stretch list** of items deferred from the original Karpathy discussion.

README and CLAUDE.md now point at this doc as the primary resume point.

## Why

Context-resilient roadmap. The next session — agent or human — should be
able to land in this repo, read one file, and know what to do next.

## Test plan

- [x] Docs-only change; CI should pass on lint/test like normal.
- [x] No code touched.