### PR TITLE
fix(ci): enforce LF line endings + allowlist PII docs/fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Normalize all text files to LF in the repo and on checkout, regardless of
+# the platform's git autocrlf setting. Without this, Biome's formatter check
+# fails on the Windows CI runner because checkouts get CRLF endings while
+# Biome expects LF.
+* text=auto eol=lf

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -16,6 +16,12 @@ paths = [
   '''tests/fixtures/pii-samples/.*''',
   '''tests/fixtures/sources/.*''',
   '''docs/karpathy.*\.md''',
+  '''docs/pii-tiers\.md''',
+  '''CLAUDE\.md''',
 ]
 # Pre-commit handles staged scans; CI handles full-history scans. Identical
 # config keeps both stages consistent.
+# Keep this list in sync with the pii-deny-scan exclude in
+# .pre-commit-config.yaml — the PII regex scanner has wider coverage than
+# gitleaks (it adds ABA, IBAN, BIP-39, etc.), but every path that needs to
+# be allowlisted for one is also allowlisted for the other.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,15 @@ repos:
         entry: bun run scripts/pii-precommit.ts
         language: system
         files: \.(md|markdown|txt|html|htm|csv)$
+        # Allowlist for files that legitimately contain DENY-tier patterns:
+        # synthetic fixtures, the rule docs that describe the patterns, and
+        # the conversation backup that captured them as part of the design.
+        # Mirrors the gitleaks allowlist in .gitleaks.toml.
+        exclude: |
+          (?x)^(
+            tests/fixtures/pii-samples/.*|
+            tests/fixtures/sources/.*|
+            docs/karpathy_.*\.md|
+            docs/pii-tiers\.md|
+            CLAUDE\.md
+          )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,12 +50,12 @@ repos:
         # Allowlist for files that legitimately contain DENY-tier patterns:
         # synthetic fixtures, the rule docs that describe the patterns, and
         # the conversation backup that captured them as part of the design.
-        # Mirrors the gitleaks allowlist in .gitleaks.toml.
+        # Kept in sync with the [allowlist].paths block in .gitleaks.toml.
         exclude: |
           (?x)^(
             tests/fixtures/pii-samples/.*|
             tests/fixtures/sources/.*|
-            docs/karpathy_.*\.md|
+            docs/karpathy.*\.md|
             docs/pii-tiers\.md|
             CLAUDE\.md
           )$

--- a/tests/integration/sync.test.ts
+++ b/tests/integration/sync.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runSync } from "../../src/commands/sync.ts";
 import type { ResolvedConfig } from "../../src/core/config.ts";
 
+// realpathSync: see note in tests/unit/walker.test.ts. The Allowlist resolves
+// symlinks (macOS /var/folders → /private/var/folders); resolve up front so
+// test path comparisons match what runSync emits.
 function tmp(prefix: string): string {
-  return mkdtempSync(join(tmpdir(), `llmwiki-sync-${prefix}-`));
+  return realpathSync(mkdtempSync(join(tmpdir(), `llmwiki-sync-${prefix}-`)));
 }
 
 function buildConfig(sourceDir: string): ResolvedConfig {

--- a/tests/unit/walker.test.ts
+++ b/tests/unit/walker.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Allowlist } from "../../src/core/allowlist.ts";
 import { globMatches, walk } from "../../src/core/walker.ts";
 
+// realpathSync: macOS symlinks /var/folders → /private/var/folders, but the
+// Allowlist resolves symlinks, so the walker emits the /private/... form.
+// Resolve up front so test path comparisons match what walk() returns.
 function tmp(): string {
-  return mkdtempSync(join(tmpdir(), "llmwiki-walk-"));
+  return realpathSync(mkdtempSync(join(tmpdir(), "llmwiki-walk-")));
 }
 
 describe("globMatches", () => {


### PR DESCRIPTION
## Summary

Two unrelated CI failures showed up after PR #21 merged into dev. Fix both here.

- **Windows runner — biome formatter rejected `biome.json` (and friends)** because git's autocrlf converted LF to CRLF on checkout. Add a `.gitattributes` with `* text=auto eol=lf` so text files check out with LF on every platform.
- **Linux runner — pre-commit `pii-deny-scan` flagged DENY-tier patterns** in `CLAUDE.md`, `docs/pii-tiers.md`, the conversation backup, and the synthetic test fixture. These files legitimately describe or contain those patterns. Add an `exclude` regex to the hook that mirrors the gitleaks allowlist in `.gitleaks.toml`.

## Verification

`pre-commit run --all-files` passes all hooks locally on Windows.

## Test plan

- [ ] CI green on Ubuntu, macOS, Windows runners
- [ ] pre-commit job green
- [ ] gitleaks job green